### PR TITLE
[ARRSOF-190] [OData Connector] Support for oData endpoints that ends with /$metadata

### DIFF
--- a/lib/schema/fetchSchema.js
+++ b/lib/schema/fetchSchema.js
@@ -2,12 +2,13 @@
 
 const request = require('request')
 const fastXmlParser = require('fast-xml-parser')
+const utils = require('../../utils/utils')
 
 // Default export
 exports.fetchSchema = function (next) {
   // Get odata service url
   var url = this.config.url
-  url = url[url.length - 1] === '/' ? url : `${url}/`
+  url = utils.getMainUrl(url)
 
   // Fetch oData $metadata
   request.get(`${url}$metadata`, (err, res) => {

--- a/test/unit/lib/schema/fetchSchema.js
+++ b/test/unit/lib/schema/fetchSchema.js
@@ -7,6 +7,11 @@ const fastXmlParser = require('fast-xml-parser')
 
 const txtSchemaXML = require('../../../txtSchemaXML')
 const fetchSchema = require('../../../../lib/schema/fetchSchema').fetchSchema
+const utils = require('../../../../utils/utils')
+
+const getMainUrlStub = sinon.stub(utils, 'getMainUrl', (url) => {
+  return 'localhost'
+})
 
 test('### Should returns no schema ###', sinon.test(function (t) {
   const cbSpy = this.spy()
@@ -22,6 +27,9 @@ test('### Should returns no schema ###', sinon.test(function (t) {
   }, cbSpy)
 
   t.notOk(schema)
+  t.ok(getMainUrlStub.calledOnce)
+
+  getMainUrlStub.reset()
   t.end()
 }))
 
@@ -43,6 +51,9 @@ test('### Should returns schema ###', sinon.test(function (t) {
   }, cbSpy)
 
   t.ok(cbSpy.calledOnce)
+  t.ok(getMainUrlStub.calledOnce)
+
+  getMainUrlStub.reset()
   t.end()
 }))
 
@@ -61,6 +72,9 @@ test('### Should returns schema ###', sinon.test(function (t) {
 
   t.ok(cbErrorSpy.calledOnce)
   t.ok(cbErrorSpy.calledWith('Error'))
+  t.ok(getMainUrlStub.calledOnce)
+
+  getMainUrlStub.reset()
   t.end()
 }))
 
@@ -80,6 +94,9 @@ test('### Should returns error ###', sinon.test(function (t) {
 
   t.ok(cbSpy.calledOnce)
   t.ok(cbSpy.calledWith({ message: 'Fail' }))
+  t.ok(getMainUrlStub.calledOnce)
+
+  getMainUrlStub.reset()
   t.end()
 }))
 
@@ -103,5 +120,8 @@ test('### Should returns error ###', sinon.test(function (t) {
 
   t.ok(cbSpy.calledOnce)
   t.ok(cbSpy.calledWith(errObj))
+  t.ok(getMainUrlStub.calledOnce)
+
+  getMainUrlStub.reset()
   t.end()
 }))

--- a/test/unit/utils/utils.js
+++ b/test/unit/utils/utils.js
@@ -244,3 +244,24 @@ test('### Should returns string query ###', function (t) {
   resolveValueStub.restore()
   t.end()
 })
+
+test('### getMainUrl should return correct string ###', function (t) {
+  const url = 'service/$metadata'
+  var mainUrl = utils.getMainUrl(url)
+  t.equals(mainUrl, 'service/')
+  t.end()
+})
+
+test('### getMainUrl should return correct string ###', function (t) {
+  const url = 'service/'
+  var mainUrl = utils.getMainUrl(url)
+  t.equals(mainUrl, 'service/')
+  t.end()
+})
+
+test('### getMainUrl should return correct string ###', function (t) {
+  const url = 'service'
+  var mainUrl = utils.getMainUrl(url)
+  t.equals(mainUrl, 'service/')
+  t.end()
+})

--- a/utils/OData.js
+++ b/utils/OData.js
@@ -22,7 +22,7 @@ module.exports = (sdk, connConfig) => {
  */
 function OData (name) {
   const url = config.url
-  this.url = url[url.length - 1] === '/' ? url : `${url}/`
+  this.url = utils.getMainUrl(url)
   this.name = name
 
   return this

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -93,3 +93,13 @@ module.exports.translateWhereToQuery = function (where, str, key) {
   }
   return str
 }
+
+/**
+ * Gets the right url from the config
+ * @param {string} url
+ * @returns {string}
+ */
+module.exports.getMainUrl = function (url) {
+  const mainUrl = url.split('/').pop() === '$metadata' ? url.replace('$metadata', '') : url
+  return mainUrl[mainUrl.length - 1] === '/' ? mainUrl : `${mainUrl}/`
+}


### PR DESCRIPTION
Currently the OData connector is generating models correctly only if the endpoint is like this http://services.odata.org/V4/TripPinService and use endpoint  that ends with $metadata (e.g. http://services.odata.org/V4/TripPinService/$metadata) internally.

The task is to add support for being able to use endpoints that ends with $metadata inside the connector config file.